### PR TITLE
event listener no longer weak

### DIFF
--- a/mockolate/src/mockolate/runner/statements/PrepareMockClasses.as
+++ b/mockolate/src/mockolate/runner/statements/PrepareMockClasses.as
@@ -38,7 +38,7 @@ package mockolate.runner.statements
 				parentToken.sendResult();
 			}
 			
-			preparer.addEventListener(Event.COMPLETE, sendResultToParent, false, 0, true);
+			preparer.addEventListener(Event.COMPLETE, sendResultToParent, false, 0);
 		}		
 		
 		override public function toString():String 


### PR DESCRIPTION
Fix to hanging tests related to https://github.com/drewbourne/mockolate/issues/51.

The previous pull request had a fix to the problem but was created/tested on code prior this commit, which introduced another problem.
https://github.com/drewbourne/mockolate/commit/b8048bda0ca4cd3fd32e5a7f2bdf512fab04a9eb

I believe Hob stopped seeing the error and had tests simply hang because of the commit above.  I saw the same behavior with the commit above.

I tested the same 2000+ test application with both fixes and everything appears to be working.

Sorry I missed this on my earlier pull request.  I had been working with old code because the same getType error was no longer happening after Drew's latest commits and I wanted to find the cause of it.
